### PR TITLE
For those using Brew -

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ $ ./script/build
 $ cp hub YOUR_BIN_PATH
 ~~~
 
+#### Brew
+
+To install `hub` on Mac OSX, you can also use brew:
+
+~~~ brew
+$ brew install hub
+~~~
+
 Or, if you've done Go development before and your $GOPATH/bin
 directory is already in your PATH:
 


### PR DESCRIPTION
I have added to the README that it is possible to use BREW under Max OSX to install hub. Most mac users will know to attempt a brew install, but it can be nice to simply inform them of the option.